### PR TITLE
Menu screen now closes (Fixes  #4)

### DIFF
--- a/js/gui/pause-handler.js
+++ b/js/gui/pause-handler.js
@@ -127,9 +127,9 @@ game.pauseHandlerEntity = me.Renderable.extend({
 			if (action === "pause") {
 
 				if (me.state.isPaused()) {
+					game.pauseHandler.enableMenu(false);
 					me.state.resume();
 					me.audio.resumeTrack();
-					game.pauseHandler.enableMenu(false);
 				}
 				else {
 					game.pauseHandler.enableMenu(true);


### PR DESCRIPTION
Resuming the soundtrack sometimes throws an exception, which leaves the text in screen. By changing the order of the calls, the text disappears. The soundtrack resuming is still an open issue.